### PR TITLE
feat: Add Google Analytics tracking

### DIFF
--- a/corvo-labs-website/src/app/layout.tsx
+++ b/corvo-labs-website/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
+import Script from 'next/script'
 import './globals.css'
 import { Header } from '@/components/header'
 import { Footer } from '@/components/footer'
@@ -29,6 +30,18 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
       >
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-QGZRCQYBWW"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-QGZRCQYBWW');
+          `}
+        </Script>
         <Header />
         <main className="flex-1">
           {children}


### PR DESCRIPTION
Adds the Google Analytics tracking script to the website. The script is added to the root layout using the Next.js Script component to ensure it is loaded on all pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Google Analytics 4 tracking, loading scripts after the app becomes interactive.
  * Ensures client-side event tracking without altering the user interface or navigation.
  * No changes to public-facing features or settings; behavior remains the same for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->