### PR TITLE
Add lower dB as new Corvo Labs project

### DIFF
--- a/corvo-labs-enhanced/docs/lower-db-linkedin-content.md
+++ b/corvo-labs-enhanced/docs/lower-db-linkedin-content.md
@@ -1,0 +1,160 @@
+# lower dB — LinkedIn & Resume Content
+
+---
+
+## 1. LinkedIn Company Profile: thelowerdb.com
+
+### Basic Information
+- **Company Name:** lower dB
+- **Tagline:** Patient-first GLP-1 intelligence. Signal over noise.
+- **Website:** https://thelowerdb.com
+- **Industry:** Online Media / Health Information
+- **Company Size:** 1-10 employees
+- **Type:** Privately Held
+- **Founded:** 2026
+
+### About Section (2,000 character limit)
+```
+lower dB is a patient-first GLP-1 intelligence desk delivering evidence-backed news, explainers, and research about GLP-1 weight-loss medications and obesity care.
+
+The name references both "decibels" (lowering the noise) and the reduction in "food noise" that patients on GLP-1 medications describe.
+
+Our editorial stance is independent: no sponsored content, no affiliate rankings, no conversion framing. We exist to help people make informed decisions about their health—not to sell them something.
+
+What we publish:
+• Evidence-backed explainers and comparisons
+• Neutral telehealth provider profiles (17+ and growing)
+• Treatment library covering medications, procedures, and devices
+• Policy briefs on insurance, access, and compounding
+• Curated reading lists from trusted external sources
+
+What powers our journalism:
+lower dB combines rigorous editorial standards with a purpose-built AI research platform. Our 11-agent pipeline—spanning research planning, source collection, claims analysis, writing, editing, and fact-checking—ensures every article is grounded in FDA labels, peer-reviewed literature, and authoritative guidance.
+
+Human editors review every piece before publication. The AI accelerates research and surfaces conflicts in evidence; humans make the final call.
+
+We believe people researching their health deserve better than affiliate-driven listicles and sponsored content dressed as journalism. lower dB is the alternative.
+```
+
+### Specialties
+GLP-1 medications, obesity treatment, health journalism, AI-assisted research, patient education, telehealth provider analysis, evidence-based content
+
+---
+
+## 2. Corvo Labs LinkedIn Post: Announcing lower dB
+
+### Post Copy (ideal length: 1,200-1,500 characters)
+```
+We built something different.
+
+lower dB (thelowerdb.com) is a patient-first GLP-1 intelligence desk—independent health journalism powered by a custom AI research platform.
+
+The problem: People researching GLP-1 medications face a wall of affiliate-driven content, sponsored rankings, and sensationalized reporting. Finding factual, evidence-backed information without sales pressure is nearly impossible.
+
+Our solution: Rigorous editorial journalism with no sponsored content, no affiliate links, no conversion framing. Just sourced, fact-checked information for people making real health decisions.
+
+The tech behind it:
+→ 11-agent AI pipeline (research planning → source collection → claims analysis → writing → editing → fact-checking → SEO)
+→ Multi-LLM orchestration: Claude Sonnet 4.6, DeepSeek v3.1, GPT-4.1-mini
+→ Risk-routing for high-stakes medical content requiring stricter review
+→ Human-in-the-loop approval at every stage
+→ Full artifact transparency and audit trails
+
+What's live:
+• 17+ neutral telehealth provider profiles
+• Treatment library (medications, procedures, devices)
+• 25-article editorial slate in production
+• Sub-$2 per article production cost with complete fact-check pipeline
+
+The name "lower dB" references both decibels (lowering the noise) and the "food noise" reduction GLP-1 patients describe.
+
+Health information should serve patients, not advertisers. That's what we're building.
+
+→ thelowerdb.com
+
+#healthtech #AI #journalism #GLP1 #obesity #healthcare
+```
+
+---
+
+## 3. Jake Butler Resume Item
+
+### Resume Entry
+```
+FOUNDER & EDITOR-IN-CHIEF
+lower dB | thelowerdb.com
+2026 – Present | Remote
+
+Patient-first GLP-1 intelligence desk combining independent health journalism with AI-powered research infrastructure.
+
+• Created editorial platform delivering evidence-backed news, explainers, and provider profiles for GLP-1 weight-loss medications—no sponsored content, no affiliate rankings
+• Architected 11-agent AI pipeline orchestrating Claude Sonnet 4.6, DeepSeek v3.1, GPT-4.1-mini, and GLM-5-Turbo for research, writing, editing, and fact-checking
+• Built risk-routing system flagging high-stakes medical content (pregnancy, adverse events, drug interactions) for stricter editorial review
+• Developed source hierarchy enforcement: FDA labels → government guidance → academic health systems → peer-reviewed literature → vetted reporting
+• Produced 17+ neutral telehealth provider dossiers and 25-article editorial slate at sub-$2 per article with full audit trails
+• Implemented human-in-the-loop approval gates ensuring every published piece passes editorial and fact-check review
+
+Tech: Next.js 16, Convex, Trigger.dev, LangChain, Arize Phoenix, Clerk
+```
+
+---
+
+## 4. Jake Butler LinkedIn Profile — Role Description
+
+### Position Details
+- **Title:** Founder & Editor-in-Chief
+- **Company:** lower dB
+- **Employment Type:** Full-time
+- **Location:** United States (Remote)
+- **Start Date:** 2026
+
+### Description (2,000 character limit)
+```
+lower dB is a patient-first GLP-1 intelligence desk I created to fix a broken information landscape. People researching weight-loss medications deserve evidence-backed journalism—not affiliate-driven content disguised as advice.
+
+What I built:
+
+Editorial platform:
+• Independent health journalism with no sponsored content, no affiliate links, no conversion framing
+• 17+ neutral telehealth provider profiles with sourced ratings, cost breakdowns, and editorial notes
+• Treatment library covering current medications, legacy drugs, bariatric procedures, and devices
+• 25-article editorial slate spanning drug comparisons, side effects, policy, and provider analysis
+
+AI research infrastructure:
+• 11-agent pipeline: Research Planner → Source Collector → Claims Analyst → Gap-Fill Search → Outline Architect → Writer → Editor → Humanizer → Fact Checker → SEO Packager → CMS Bridge
+• Multi-LLM orchestration across Claude Sonnet 4.6 (writing/editing), DeepSeek v3.1 (research/claims), GPT-4.1-mini (fact-checking/SEO), GLM-5-Turbo (gap-fill query selection)
+• Risk-routing system for high-stakes medical topics requiring stricter editorial gates
+• Human-in-the-loop approval ensuring every article passes manual review before publication
+• Full artifact transparency: every research plan, source log, claims table, draft, and fact-check report is preserved
+
+The name references both "decibels" (lowering the noise) and the "food noise" reduction that GLP-1 patients describe. That's the mission: signal over noise for people making real health decisions.
+
+A Corvo Labs property.
+```
+
+---
+
+## Quick Reference: Key Messaging Points
+
+**Brand concept:**
+- "lower dB" = decibels (lowering the noise) + food noise reduction
+- Tagline: "Patient-first GLP-1 intelligence. Signal over noise."
+
+**Editorial differentiators:**
+- No sponsored content
+- No affiliate rankings
+- No conversion framing
+- Evidence-backed, sourced journalism
+
+**Technical differentiators:**
+- 11-agent AI pipeline
+- Multi-LLM orchestration (4 models, task-specialized)
+- Risk-routing for medical content
+- Human-in-the-loop at every stage
+- Sub-$2 per article with full audit trail
+
+**Content scope:**
+- 17+ telehealth provider profiles
+- 25-article editorial slate
+- Treatment library (meds, procedures, devices)
+- Policy briefs and curated reading lists

--- a/corvo-labs-enhanced/src/app/projects/page.tsx
+++ b/corvo-labs-enhanced/src/app/projects/page.tsx
@@ -38,6 +38,38 @@ const categories = [
 
 const projects = [
   {
+    id: 7,
+    title: "lower dB",
+    category: "ai-tools",
+    client: "thelowerdb.com",
+    location: "United States",
+    duration: "Ongoing",
+    challenge: "People researching GLP-1 medications face a landscape polluted by affiliate-driven content, sponsored rankings, and sensationalized reporting. Finding factual, evidence-backed information without sales pressure is nearly impossible, leaving patients to navigate complex medical decisions through noise rather than signal.",
+    solution: "Built a patient-first GLP-1 intelligence desk that combines independent editorial journalism with a multi-agent AI research and writing platform. The name references both 'decibels' (lowering the noise) and the reduction in 'food noise' that GLP-1 patients describe. No sponsored content, no affiliate rankings, no conversion framing—just rigorous, sourced journalism.",
+    process: [
+      "Designed 11-agent pipeline: Research Planner, Source Collector, Claims Analyst, Gap-Fill Search, Outline Architect, Writer, Editor, Humanizer, Fact Checker, SEO Packager, and CMS Bridge",
+      "Implemented multi-LLM orchestration across Claude Sonnet 4.6, DeepSeek v3.1, GPT-4.1-mini, and GLM-5-Turbo for specialized tasks",
+      "Built risk-routing system for high-stakes medical content requiring stricter editorial review",
+      "Integrated Firecrawl for source collection and Tavily for gap-fill research enrichment",
+      "Engineered human-in-the-loop approval gates with full artifact transparency"
+    ],
+    results: [
+      "17+ telehealth provider dossiers with neutral, sourced profiles",
+      "25-article editorial slate covering drugs, providers, costs, side effects, research, and policy",
+      "Full fact-check pipeline with FDA labels, peer-reviewed literature, and government guidance as source hierarchy",
+      "Sub-$2 per article production cost with complete audit trail"
+    ],
+    technologies: [
+      "Next.js 16 App Router",
+      "Convex (reactive backend)",
+      "Trigger.dev (durable workflows)",
+      "Claude Sonnet 4.6 / DeepSeek v3.1 / GPT-4.1-mini",
+      "Arize Phoenix (observability)",
+      "Clerk Auth"
+    ],
+    image: "/images/lower-db.jpg"
+  },
+  {
     id: 1,
     title: "Kinisi",
     category: "patient",


### PR DESCRIPTION
## Summary
Adds **lower dB** (thelowerdb.com) as a featured project on the Corvo Labs website.

## Changes
- **Projects page**: Added lower dB as the first project entry, positioned as both a patient-first newsroom and AI-powered research platform
- **LinkedIn content**: Created docs with company profile, Corvo Labs announcement post, resume item, and LinkedIn role description

## lower dB Highlights
- Patient-first GLP-1 intelligence desk with independent editorial stance (no sponsored content, no affiliate rankings)
- 11-agent AI pipeline: Research Planner → Source Collector → Claims Analyst → Gap-Fill Search → Outline Architect → Writer → Editor → Humanizer → Fact Checker → SEO Packager → CMS Bridge
- Multi-LLM orchestration (Claude Sonnet 4.6, DeepSeek v3.1, GPT-4.1-mini, GLM-5-Turbo)
- Risk-routing for high-stakes medical content
- Human-in-the-loop approval gates

## Preview
This PR should trigger a Vercel preview deployment. Check the preview URL in the deployment status below.

## Files Changed
- `corvo-labs-enhanced/src/app/projects/page.tsx` - Added lower dB project entry
- `corvo-labs-enhanced/docs/lower-db-linkedin-content.md` - LinkedIn and resume content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "lower dB" project to the projects showcase with full details including challenge, solution, approach, results, and technologies used.

* **Documentation**
  * Added brand messaging templates and LinkedIn marketing content for lower dB promotion across channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->