### PR TITLE
chore: add dev environment setup (ESLint config + AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Next.js 15 website (Corvo Labs AI consulting) located in `/workspace/corvo-labs-enhanced/`. Single service, no databases, no Docker. All commands run from that directory.
+
+### Running the application
+
+```bash
+cd /workspace/corvo-labs-enhanced
+bun dev          # Dev server at http://localhost:3000
+```
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Dev server | `bun dev` |
+| Build | `bun run build` |
+| Type check | `bun type-check` |
+| Lint (ESLint CLI) | `npx eslint ./src` |
+
+### Non-obvious notes
+
+- **`next lint` is deprecated** in Next.js 15.5+. Use `npx eslint ./src` directly instead.
+- **No ESLint config existed in the repo** — `eslint.config.mjs` was added during setup. Without it, neither `next lint` nor `bun run build` can succeed.
+- **`react/no-unescaped-entities`** is downgraded to a warning in the ESLint config because the existing codebase has multiple unescaped apostrophes/quotes. The build would fail with it as an error.
+- **External services are optional**: Resend (email), MailerLite (newsletter), PostHog (analytics) require API keys in `.env.local` but the site runs fully without them. The contact form returns a clear error about missing `RESEND_API_KEY` when not configured.
+- **Bun is the preferred runtime** (`bun.lock` present). Node/npm also works but Bun is faster.
+- **Husky pre-commit hook** runs `corvo-labs-enhanced/scripts/coderabbit-review.sh` which may require the CodeRabbit CLI. This can be skipped in cloud agent environments.
+- **No automated test suite** exists in this project (no test runner configured, no test files).

--- a/corvo-labs-enhanced/eslint.config.mjs
+++ b/corvo-labs-enhanced/eslint.config.mjs
@@ -1,0 +1,21 @@
+import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next"),
+  {
+    rules: {
+      "react/no-unescaped-entities": "warn",
+    },
+  },
+];
+
+export default eslintConfig;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the necessary configuration files for a working development environment:

1. **`corvo-labs-enhanced/eslint.config.mjs`** — ESLint 9 flat config using `eslint-config-next`. The project had ESLint dependencies in `package.json` but no config file, causing both `next lint` and `next build` to fail. The `react/no-unescaped-entities` rule is downgraded to a warning since the existing codebase has unescaped quotes/apostrophes.

2. **`AGENTS.md`** — Development instructions for Cursor Cloud agents, documenting key commands, non-obvious gotchas (deprecated `next lint`, missing ESLint config, optional external services), and the fact that no automated test suite exists.

## Verification

All development workflows pass:
- `bun type-check` — clean
- `npx eslint ./src` — runs (warnings only, no errors)
- `bun run build` — succeeds
- `bun dev` — serves at localhost:3000

[corvo_labs_site_demo.mp4](https://cursor.com/agents/bc-f21d10ea-ca34-4a93-8852-3334ae598343/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcorvo_labs_site_demo.mp4)

[Homepage](https://cursor.com/agents/bc-f21d10ea-ca34-4a93-8852-3334ae598343/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Blog page](https://cursor.com/agents/bc-f21d10ea-ca34-4a93-8852-3334ae598343/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_page.webp)
[Contact form](https://cursor.com/agents/bc-f21d10ea-ca34-4a93-8852-3334ae598343/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f21d10ea-ca34-4a93-8852-3334ae598343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f21d10ea-ca34-4a93-8852-3334ae598343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

